### PR TITLE
Trivial POD change to fix synopsis rendering

### DIFF
--- a/lib/Apache/OneTimeURL.pm
+++ b/lib/Apache/OneTimeURL.pm
@@ -115,6 +115,7 @@ Apache::OneTimeURL - One-time use URLs for sensitive data
     </Location>
 
 F<authorize.pl>:
+
     #!/usr/bin/perl
     use Apache::OneTimeURL;
     my $comments = join " ", @ARGV;


### PR DESCRIPTION
This change adds an empty line to ensure that the sample authorize.pl in the synopsis renders as code instead of prose.

This is a fix of issue #1 in my fork.
